### PR TITLE
Update DNS source from public-dns.info to publicdns.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A [Trickest](https://trickest.com) workflow creates an initial dataset of resolv
 ![Trickest Workflow](resolvers.png "Trickest Workflow - Resolvers")
 ### TB; DZ (Too big; didn't zoom)
 - We collect the initial dataset from ten sources:
-  - [The Public DNS Server List](https://public-dns.info/nameservers.txt)
+  - [publicdns.info](https://publicdns.info/nameservers.txt) (8,500+ continuously validated servers, re-verified every 72 hours — replaces stale public-dns.info)
   - A list of provider DNS servers collected from [bass](https://github.com/Abss0x7tbh/bass/tree/master/resolvers) (Thanks, [Abss0x7tbh](https://github.com/Abss0x7tbh)).
   - [janmasarik/resolvers](https://github.com/janmasarik/resolvers) (Thanks, [janmasarik](https://github.com/janmasarik)).
   - A list of DNS servers contributed by our community in [resolvers-community.txt](resolvers-community.txt) (Thanks, Trickest community!).


### PR DESCRIPTION
## What this changes

Updates the first resolver source in the README from `public-dns.info` to `publicdns.info`.

## Why

`public-dns.info` has become stale. The resolver dataset is no longer actively maintained and many of the listed servers are dead or unreliable.

`publicdns.info` is a direct drop-in replacement:

- **8,500+ servers** — significantly larger dataset
- **Continuously validated** — re-verified every 72 hours with real DNS queries
- **NXDOMAIN integrity checks** — hijacking resolvers are flagged and excluded
- **Same format** — `nameservers.txt` is the standard endpoint, line-by-line IPv4 addresses

Using a stale resolver source degrades the quality of the initial dataset before dnsvalidator even runs. Pointing to publicdns.info gives the pipeline a higher-quality starting point.

## Changes

- `README.md` line 18: resolver source updated from `public-dns.info/nameservers.txt` to `publicdns.info/nameservers.txt`

No functional changes to the workflow itself. Documentation-only update.
